### PR TITLE
fix: skip (as missing) entries with no item/rate/customer

### DIFF
--- a/lib/goosebay.js
+++ b/lib/goosebay.js
@@ -589,6 +589,7 @@ class GooseBay {
         const fails = new Set();
         const upds = new Set();
         const skips = new Set();
+        const missings = new Set();
 
         for (const [TxnDate, kinds] of Object.entries(p)) {
             console.log('=' + TxnDate);
@@ -615,8 +616,11 @@ class GooseBay {
                 };
                 console.dir(req);
                 const skipKey = `c${o.customer_id}:i${o.item_id}`;
-                if (existing[req.TxnDate]?.has(skipKey)) {
-                    console.log('Skipping ' + req.TxnDate + ' ' + skipKey );
+                if (!req.HourlyRate || !req.CustomerRef.value || !req.ItemRef.value) {
+                    console.log('Skipping (no data) ' + req.TxnDate + ' ' + skipKey );
+                    missings.add(req.TxnDate + ' ' + skipKey);
+                } else if (existing[req.TxnDate]?.has(skipKey)) {
+                    console.log('Skipping (exists) ' + req.TxnDate + ' ' + skipKey );
                     skips.add(req.TxnDate + ' ' + skipKey);
                 } else if (!DRY_RUN) {
                     try {
@@ -627,6 +631,8 @@ class GooseBay {
                         console.error(e);
                         fails.add(req.TxnDate);
                     }
+                } else {
+                    upds.add(req.TxnDate);
                 }
             }
         }
@@ -634,7 +640,7 @@ class GooseBay {
         // const r = await t.add(p);
         // console.dir(r, { depth: Infinity, color: true });
 
-        console.dir({skips, upds, fails});
+        console.dir({skips, upds, fails, missings});
         if (DRY_RUN) {
             console.log('** set GOOSE_BAY_COMMIT=1 to commit **');
             return { DRY_RUN };


### PR DESCRIPTION
- also add a 'missings' group
- also update 'upds' when in dry run